### PR TITLE
Enable clean.fs.before.tests by default

### DIFF
--- a/vee-port/validation/fs/validation/microej-testsuite-common.properties
+++ b/vee-port/validation/fs/validation/microej-testsuite-common.properties
@@ -4,6 +4,11 @@
 # Values are: caseInsensitive, caseSensitive (default).
 #microej.java.property.case.sensitivity=caseInsensitive
 
+# Empties the `user.dir` and `java.io.tmpdir` directories (defined in vee-port/configuration.properties) before the
+# test suite runs. Enabled by default, since leftover files accumulate in these directories over time and progressively
+# slow down test suite execution.
+microej.java.property.clean.fs.before.tests=true
+
 # Pack FS 4.x Options 
 com.is2t.fs.embedded.resources.io.file.max.access=2
 com.is2t.fs.embedded.resources.io.file.max.path.length=256


### PR DESCRIPTION
Expose property `clean.fs.before.tests` in FS testsuite properties, invisible otherwise.

Default its value to true. Files accumulate overtime, which progressively slows down the testsuite execution, to the point where a board in CI would eventually timeout.

I see no reason to keep it disabled.